### PR TITLE
Feature:  Add plop script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "cypress:open": "cypress open",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "plop": "plop"
   },
   "dependencies": {
     "@types/node": "20.5.6",


### PR DESCRIPTION
## Summary
1. Add plop script in package.json to make plop work without installing it globally into each machine